### PR TITLE
Pass encoding into its attribute

### DIFF
--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -194,7 +194,8 @@ around BUILDARGS => sub {
     my $timeout = delete($args{timeout});
     my $ua_obj = delete($args{ua_obj});
     my $processors = delete($args{processors}) || [];
-
+    my $encoding = delete($args{encoding});
+    
     return $class->$orig(
         post_url   => $post_url,
         public_key => $public_key,
@@ -202,6 +203,7 @@ around BUILDARGS => sub {
         context    => \%args,
         processors => $processors,
 
+        (defined($encoding) ? (encoding => $encoding) : ()),
         (defined($timeout) ? (timeout => $timeout) : ()),
         (defined($ua_obj) ? (ua_obj => $ua_obj) : ()),
     );


### PR DESCRIPTION
This fixes a bug (introduced in #5)  where a user was unable to set the new encoding attribute when the object is instantiated.