### PR TITLE
Add support for fingerprint attribute

### DIFF
--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -111,7 +111,7 @@ has [qw/ post_url public_key secret_key /] => (
 has sentry_version => (
     is      => 'ro',
     isa     => Int,
-    default => 3,
+    default => 7,
 );
 
 has timeout => (
@@ -581,6 +581,7 @@ sub _construct_event {
 
         extra       => $self->_merge_hashrefs($self->context()->{extra}, $context{extra}),
         tags        => $self->_merge_hashrefs($self->context()->{tags}, $context{tags}),
+        fingerprint => $context{fingerprint} || $self->context()->{fingerprint} || ['{{ default }}'],
 
         level       => $self->_validate_level($context{level}) || $self->context()->{level} || 'error',
     };
@@ -863,6 +864,12 @@ The hostname on which an event occurred.  Defaults to the system hostname.
 =item C<< tags => { key1 => 'val1, ... } >>
 
 Arbitrary key value pairs with tags for categorizing an event.  Defaults to C<{}>.
+
+=item C<< fingerprint => [ 'val1', 'val2', ... } >>
+
+Array of strings used to control grouping of events into rollups. The string C<'{{ default }}'> has special meaning when
+used as the first value; it indicates subsequent values should be appended to Sentry's default fingerprint (useful for
+splitting a rollup into multiple ones). Defaults to C<['{{ default }}']>.
 
 =item C<< timestamp => '1970-01-01T00:00:00' >>
 

--- a/t/11-generic-event.t
+++ b/t/11-generic-event.t
@@ -28,6 +28,7 @@ subtest 'defaults' => sub {
 
     is_deeply($event->{extra}, {});
     is_deeply($event->{tags}, {});
+    is_deeply($event->{fingerprint}, ['{{ default }}']);
 
     ok(string_to_uuid($event->{event_id}));
     like($event->{timestamp}, qr/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d$/);
@@ -51,6 +52,10 @@ subtest 'modifying defaults' => sub {
             tag1    => 'value1',
             tag2    => 'value2',
         },
+        fingerprint => [
+            'new',
+            'fingerprint',
+        ],
 
         event_id    => 'myeventid',
         timestamp   => 'mytimestamp',
@@ -81,6 +86,14 @@ subtest 'modifying defaults' => sub {
             tag1    => 'value1',
             tag2    => 'value2',
         },
+    );
+
+    is_deeply(
+        $event->{fingerprint},
+        [
+            'new',
+            'fingerprint',
+        ],
     );
 
     is($event->{event_id}, 'myeventid');
@@ -155,6 +168,10 @@ subtest 'overriding defaults' => sub {
             tag1    => 'value1',
             tag2    => 'value2',
         },
+        fingerprint => [
+            'new',
+            'fingerprint',
+        ],
 
         event_id    => 'myeventid',
         timestamp   => 'mytimestamp',
@@ -183,6 +200,14 @@ subtest 'overriding defaults' => sub {
         },
     );
 
+    is_deeply(
+        $event->{fingerprint},
+        [
+            'new',
+            'fingerprint',
+        ],
+    );
+
     is($event->{event_id}, 'myeventid');
     is($event->{timestamp}, 'mytimestamp');
     is($event->{server_name}, 'myservername');
@@ -197,6 +222,9 @@ subtest 'overriding modified defaults' => sub {
         tags        => {
             tag1    => 'value1',
         },
+        fingerprint => [
+            'value1',
+        ],
     );
 
     my $event = $raven->_construct_event(
@@ -208,6 +236,9 @@ subtest 'overriding modified defaults' => sub {
         tags        => {
             tag2    => 'value2',
         },
+        fingerprint => [
+            'value2',
+        ],
     );
 
     is($event->{level}, 'fatal');
@@ -226,6 +257,13 @@ subtest 'overriding modified defaults' => sub {
             tag1    => 'value1',
             tag2    => 'value2',
         },
+    );
+
+    is_deeply(
+        $event->{fingerprint},
+        [
+            'value2',
+        ],
     );
 };
 


### PR DESCRIPTION
The fingerprint attribute would be useful for more fine-grained control over how Sentry groups events into rollups.