### PR TITLE
Fix stacktraces

### DIFF
--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -233,7 +233,7 @@ sub capture_errors {
 
     my ($stacktrace, @retval);
     eval {
-        local $SIG{__DIE__} = sub { $stacktrace = Devel::StackTrace->new() };
+        local $SIG{__DIE__} = sub { $stacktrace = Devel::StackTrace->new(skip_frames => 1) };
 
         if ($wantarray) {
             @retval = $subref->();
@@ -250,10 +250,7 @@ sub capture_errors {
 
         my %stacktrace_context = $stacktrace
             ? $self->stacktrace_context(
-                $self->_get_frames_from_devel_stacktrace(
-                    $stacktrace,
-                    1, # ignore 1 frame: $SIG{__DIE__}->()
-                ),
+                $self->_get_frames_from_devel_stacktrace($stacktrace),
             )
             : ();
 
@@ -275,9 +272,7 @@ sub capture_errors {
 };
 
 sub _get_frames_from_devel_stacktrace {
-    my ($self, $stacktrace, $ignore_num_frames) = @_;
-
-    $ignore_num_frames ||= 0;
+    my ($self, $stacktrace) = @_;
 
     my @frames = map {
         my $frame = $_;
@@ -302,8 +297,6 @@ sub _get_frames_from_devel_stacktrace {
         my $parent = $frames[$i + 1] // {};
         @$frame{'function', 'vars'} = @$parent{'function', 'vars'};
     }
-
-    shift(@frames) while ($ignore_num_frames--);
 
     return [ reverse(@frames) ];
 }

--- a/t/12-specialized-event.t
+++ b/t/12-specialized-event.t
@@ -116,11 +116,6 @@ subtest 'stacktrace' => sub {
         $raven->_construct_stacktrace_event($trace)->{'sentry.interfaces.Stacktrace'},
         { frames => $frames },
     );
-
-    is_deeply(
-        $raven->_get_frames_from_devel_stacktrace($trace, 1),
-        [ $frames->[0] ],
-    );
 };
 
 subtest 'user' => sub {

--- a/t/12-specialized-event.t
+++ b/t/12-specialized-event.t
@@ -95,21 +95,19 @@ subtest 'stacktrace' => sub {
         {
             abs_path => File::Spec->catfile('t', '12-specialized-event.t'),
             filename => '12-specialized-event.t',
-            function => 'main::a',
+            function => undef,
             lineno   => 17,
             module   => 'main',
-            vars     => {
-                '@_' => ['1','"x"'],
-            },
+            vars     => undef
         },
         {
             abs_path => File::Spec->catfile('t', '12-specialized-event.t'),
             filename => '12-specialized-event.t',
-            function => 'Devel::StackTrace::new',
+            function => 'main::a',
             lineno   => 16,
             module   => 'main',
             vars     => {
-                '@_' => ['"Devel::StackTrace"'],
+                '@_' => ['1','"x"'],
             },
         },
     ];

--- a/t/15-error-handler.t
+++ b/t/15-error-handler.t
@@ -55,13 +55,13 @@ subtest 'exception' => sub {
 subtest 'stacktrace' => sub {
     my @frames = @{ $event->{'sentry.interfaces.Stacktrace'}->{frames} };
 
-    is(scalar(@frames), 6);
+    is(scalar(@frames), 7);
 
     is($frames[-1]->{function}, 'main::c');
     is($frames[-1]->{module}, 'main');
     is($frames[-1]->{abs_path}, File::Spec->catfile('t', '15-error-handler.t'));
     is($frames[-1]->{filename}, '15-error-handler.t');
-    is($frames[-1]->{lineno}, 33);
+    is($frames[-1]->{lineno}, 34);
 };
 
 subtest 'dies when unable to submit event' => sub {


### PR DESCRIPTION
Previously stacktraces were confusing because they combine functions and line numbers from different stack frames. This should fix that.
