### PR TITLE
Add environment as context to events

### DIFF
--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -587,7 +587,7 @@ sub _construct_event {
         fingerprint     => $context{fingerprint} || $self->context()->{fingerprint} || ['{{ default }}'],
 
         level           => $self->_validate_level($context{level}) || $self->context()->{level} || 'error',
-        environment     => $context{environment} || $self->context()->{environment},
+        environment     => $context{environment} || $self->context()->{environment} || $ENV{SENTRY_ENVIRONMENT},
     };
 
     $event->{message} = _trim($event->{message}, MAX_MESSAGE);

--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -571,22 +571,23 @@ sub _construct_event {
     my ($self, %context) = @_;
 
     my $event = {
-        event_id    => $context{event_id}    || $self->context()->{event_id}    || _generate_id(),
-        timestamp   => $context{timestamp}   || $self->context()->{timestamp}   || DateTime->now()->iso8601(),
-        logger      => $context{logger}      || $self->context()->{logger}      || 'root',
-        server_name => $context{server_name} || $self->context()->{server_name} || hostname(),
-        platform    => $context{platform}    || $self->context()->{platform}    || 'perl',
+        event_id        => $context{event_id}    || $self->context()->{event_id}    || _generate_id(),
+        timestamp       => $context{timestamp}   || $self->context()->{timestamp}   || DateTime->now()->iso8601(),
+        logger          => $context{logger}      || $self->context()->{logger}      || 'root',
+        server_name     => $context{server_name} || $self->context()->{server_name} || hostname(),
+        platform        => $context{platform}    || $self->context()->{platform}    || 'perl',
 
-        release     => $context{release}     || $self->context()->{release},
+        release         => $context{release}     || $self->context()->{release},
 
-        message     => $context{message}     || $self->context()->{message},
-        culprit     => $context{culprit}     || $self->context()->{culprit},
+        message         => $context{message}     || $self->context()->{message},
+        culprit         => $context{culprit}     || $self->context()->{culprit},
 
-        extra       => $self->_merge_hashrefs($self->context()->{extra}, $context{extra}),
-        tags        => $self->_merge_hashrefs($self->context()->{tags}, $context{tags}),
-        fingerprint => $context{fingerprint} || $self->context()->{fingerprint} || ['{{ default }}'],
+        extra           => $self->_merge_hashrefs($self->context()->{extra}, $context{extra}),
+        tags            => $self->_merge_hashrefs($self->context()->{tags}, $context{tags}),
+        fingerprint     => $context{fingerprint} || $self->context()->{fingerprint} || ['{{ default }}'],
 
-        level       => $self->_validate_level($context{level}) || $self->context()->{level} || 'error',
+        level           => $self->_validate_level($context{level}) || $self->context()->{level} || 'error',
+        environment     => $context{environment} || $self->context()->{environment},
     };
 
     $event->{message} = _trim($event->{message}, MAX_MESSAGE);

--- a/t/11-generic-event.t
+++ b/t/11-generic-event.t
@@ -26,6 +26,7 @@ subtest 'defaults' => sub {
     is($event->{culprit}, undef);
     is($event->{message}, undef);
     is($event->{release}, undef);
+    is($event->{environment}, undef);
 
     is_deeply($event->{extra}, {});
     is_deeply($event->{tags}, {});
@@ -45,6 +46,7 @@ subtest 'modifying defaults' => sub {
         message     => 'mymessage',
         encoding    => 'base64',
         release     => 'ec899ea',
+        environment => 'testing',
 
         extra       => {
             key1    => 'value1',
@@ -74,6 +76,7 @@ subtest 'modifying defaults' => sub {
     is($event->{culprit}, 'myculprit');
     is($event->{message}, 'mymessage');
     is($event->{release}, 'ec899ea');
+    is($event->{release}, 'testing');
 
     is_deeply(
         $event->{extra},


### PR DESCRIPTION
This adds environment to the context so we can separate _production_, _staging_, _dev_, etc. in a single project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/perl-raven/16)
<!-- Reviewable:end -->
