### PR TITLE
Increase MAX_EXCEPTION_VALUE to 4096

### DIFF
--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -27,7 +27,7 @@ use constant {
     MAX_MESSAGE               => 2048,
 
     MAX_EXCEPTION_TYPE        =>  128,
-    MAX_EXCEPTION_VALUE       =>  256,
+    MAX_EXCEPTION_VALUE       => 4096,
 
     MAX_HTTP_QUERY_STRING     => 1024,
     MAX_HTTP_DATA             => 2048,


### PR DESCRIPTION
This is the current server limit; see https://github.com/getsentry/sentry/commit/e621699

I'd like to see it bumped here too, because 256 is too small for some of the exception messages we're seeing.