### PR TITLE
Use Time::Piece instead of DateTime, because DateTime is slow

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,6 @@ WriteMakefile1(
 
     PREREQ_PM           => {
         'Data::Dump'                   => 0,
-        'DateTime'                     => 0,
         'Devel::StackTrace'            => 0,
         'English'                      => 0,
         'File::Basename'               => 0,
@@ -22,6 +21,7 @@ WriteMakefile1(
         'Moo'                          => 0,
         'MooX::Types::MooseLike::Base' => 0,
         'Sys::Hostname'                => 0,
+        'Time::Piece'                  => 0,
         'URI'                          => 0,
         'UUID::Tiny'                   => 0,
     },

--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -9,7 +9,6 @@ use MooX::Types::MooseLike::Base qw/ ArrayRef HashRef Int Str /;
 our $VERSION = '1.08';
 
 use Data::Dump 'dump';
-use DateTime;
 use Devel::StackTrace;
 use English '-no_match_vars';
 use File::Basename 'basename';
@@ -18,6 +17,7 @@ use HTTP::Status ':constants';
 use JSON::XS;
 use LWP::UserAgent;
 use Sys::Hostname;
+use Time::Piece;
 use URI;
 use UUID::Tiny ':std';
 
@@ -574,7 +574,7 @@ sub _construct_event {
 
     my $event = {
         event_id        => $context{event_id}    || $self->context()->{event_id}    || _generate_id(),
-        timestamp       => $context{timestamp}   || $self->context()->{timestamp}   || DateTime->now()->iso8601(),
+        timestamp       => $context{timestamp}   || $self->context()->{timestamp}   || gmtime->datetime(),
         logger          => $context{logger}      || $self->context()->{logger}      || 'root',
         server_name     => $context{server_name} || $self->context()->{server_name} || hostname(),
         platform        => $context{platform}    || $self->context()->{platform}    || 'perl',


### PR DESCRIPTION
Hi, I'm always helped by this module, thank your for nice software :)

And now, I know that DateTime is a little slow.  Benchmark is the below:

```pl
$ cat benchmark.pl
use Benchmark qw/ cmpthese /;
use Time::Piece ();
use DateTime;

cmpthese 0, {
    'Time::Piece'  => sub { Time::Piece->gmtime->datetime },
    'DateTime'     => sub { DateTime->now->iso8601 },
};

$ carton exec perl benchmark.pl
                Rate    DateTime Time::Piece
DateTime     31129/s          --        -78%
Time::Piece 140805/s        352%          --
```

Are you interested in replacing it to Time::Piece?  This PR did it.

Anyway thank you for your helping via OSS!
