### PR TITLE
Improve user context support

### DIFF
--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -462,13 +462,13 @@ C<%user_context> can contain:
 
 =over
 
-=item C<< id => $unique_id' >>
+=item C<< id => $unique_id >>
 
-=item C<< username => $username' >>
+=item C<< username => $username >>
 
-=item C<< email => $email' >>
+=item C<< email => $email >>
 
-=item C<< ip_address => $ip_address' >>
+=item C<< ip_address => $ip_address >>
 
 =back
 

--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -42,6 +42,7 @@ use constant {
     MAX_USER_EMAIL            =>  128,
     MAX_USER_ID               =>  128,
     MAX_USER_USERNAME         =>  128,
+    MAX_USER_IP_ADDRESS       =>   45, # RFC 4291, section 2.2.3
 };
 
 # self-imposed constants
@@ -467,6 +468,8 @@ C<%user_context> can contain:
 
 =item C<< email => $email' >>
 
+=item C<< ip_address => $ip_address' >>
+
 =back
 
 =cut
@@ -481,7 +484,9 @@ sub _construct_user_event {
 
     return $self->_construct_event(
         %context,
-        $self->user_context(%context),
+        $self->user_context(
+            map { $_ => $context{$_} } qw/email id username ip_address/
+        ),
     );
 };
 
@@ -718,12 +723,15 @@ sub stacktrace_context {
 
 sub user_context {
     my ($class, %user_context) = @_;
+    my ($email, $id, $username, $ip_address) = delete @user_context{qw/email id username ip_address/};
 
     return (
         'sentry.interfaces.User' => {
-            email    => _trim($user_context{email}, MAX_USER_EMAIL),
-            id       => _trim($user_context{id}, MAX_USER_ID),
-            username => _trim($user_context{username}, MAX_USER_USERNAME),
+            email      => _trim($email, MAX_USER_EMAIL),
+            id         => _trim($id, MAX_USER_ID),
+            username   => _trim($username, MAX_USER_USERNAME),
+            ip_address => _trim($ip_address, MAX_USER_IP_ADDRESS),
+            %user_context,
         }
     );
 };

--- a/t/12-specialized-event.t
+++ b/t/12-specialized-event.t
@@ -119,17 +119,23 @@ subtest 'stacktrace' => sub {
 };
 
 subtest 'user' => sub {
-    my $event = $raven->_construct_user_event( id => 'myid', username => 'myusername', email => 'my@email.com', level => 'info');
+    my $event = $raven->_construct_user_event(id => 'myid', username => 'myusername', email => 'my@email.com', ip_address => '192.168.0.1', level => 'info');
 
     is($event->{level}, 'info');
     is_deeply(
         $event->{'sentry.interfaces.User'},
         {
-            id       => 'myid',
-            username => 'myusername',
-            email    => 'my@email.com',
+            id            => 'myid',
+            username      => 'myusername',
+            email         => 'my@email.com',
+            ip_address    => '192.168.0.1',
         },
     );
+};
+
+subtest 'user_context arbitray data' => sub {
+    my $event = {$raven->user_context(arbitrary_key => 'arbitrary value')};
+    is($event->{'sentry.interfaces.User'}{arbitrary_key}, 'arbitrary value');
 };
 
 subtest 'query' => sub {


### PR DESCRIPTION
I'd like to add support for IP addresses and arbitrary user data in user contexts. There are a few possible wrinkles however:

- If `_construct_user_event()` passes all parameters to `user_context()`, then `level`/`tags`/etc end up being treated like arbitrary user data. I've solved this by making it so that `capture_user()` simply does not support arbitrary user data (but `user_context()` does).
- There's duplication in terms of the list of official user-related fields. Would you like me to adhere to DRY a bit better?
- Should I split off the commit for adding IP address support from the commit that adds arbitrary user data support?