### PR TITLE
Instance context interfaces

### DIFF
--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -600,9 +600,11 @@ sub _construct_event {
     $event->{message} = _trim($event->{message}, MAX_MESSAGE);
     $event->{culprit} = _trim($event->{culprit}, MAX_CULPRIT);
 
+    my $instance_ctx = $self->context();
     foreach my $interface (@{ $self->valid_interfaces() }) {
-        $event->{$interface} = $context{$interface}
-            if $context{$interface};
+        my $interface_ctx = $context{$interface} || $instance_ctx->{$interface};
+        $event->{$interface} = $interface_ctx
+            if $interface_ctx;
     }
 
     return $event;

--- a/t/11-generic-event.t
+++ b/t/11-generic-event.t
@@ -285,4 +285,19 @@ subtest 'invalid context' => sub {
     is($warn_message, "unknown level: not-a-level\n");
 };
 
+subtest 'generic interfaces' => sub {
+    # request_context is probably a more real-world example of this
+    # but exception_context is conveniently easy to create
+    my %exception_context = Sentry::Raven->exception_context("error message");
+    $raven = Sentry::Raven->new( %exception_context );
+
+    my $event = $raven->_construct_event();
+
+    for my $exception_key ( keys %exception_context ) {
+        is_deeply $event->{ $exception_key },
+                  $exception_context{ $exception_key },
+                  "instance-level $exception_key appears in events";
+    }
+};
+
 done_testing();


### PR DESCRIPTION
Sending messages will now fall back to interface contexts recorded on the Sentry instance. Previously, adding eg. the request interface context to an instantiated Sentry object would have been ignored when sending a message.