### PR TITLE
handle Devel::StackTrace frames from unreadable files

### DIFF
--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -310,8 +310,10 @@ sub _get_frames_from_devel_stacktrace {
 sub _get_lines_from_file {
   my ($self, $abs_path, $lineno) = @_;
 
-  my @lines = read_file($abs_path);
+  my @lines = eval { read_file($abs_path) };
   chomp(@lines);
+  return () unless @lines;
+  return () unless @lines >= $lineno;
   
   my $context_lines = 5;
   my $lower_bound = max(0, $lineno - $context_lines);

--- a/t/21-stacktrace-failures.t
+++ b/t/21-stacktrace-failures.t
@@ -1,0 +1,56 @@
+#!/usr/bin/env perl -T
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use File::Slurp;
+use File::Spec;
+use Sentry::Raven;
+use Devel::StackTrace;
+
+local $ENV{SENTRY_DSN} = 'http://key:secret@somewhere.com:9000/foo/123';
+my $raven = Sentry::Raven->new();
+
+my $trace;
+a(1,"x");
+
+my @file_lines = read_file(File::Spec->catfile('t', '21-stacktrace-failures.t'));
+chomp(@file_lines);
+
+my $frames = [
+    {
+        abs_path     => File::Spec->catfile('t', '21-stacktrace-failures.t'),
+        filename     => '21-stacktrace-failures.t',
+        function     => undef,
+        lineno       => 17,
+        module       => 'main',
+        vars         => undef,
+        context_line => $file_lines[ 16 ],
+        pre_context  => [ @file_lines[ 11 .. 15 ] ],
+        post_context => [ @file_lines [ 17 .. 21 ] ],
+    },
+    {
+        abs_path => '/bad/path/NoSuchFileEver.pm',
+        filename => 'NoSuchFileEver.pm',
+        function => 'main::a',
+        lineno   => 127,
+        module   => 'main',
+        vars     => {
+            '@_' => ['1','"x"'],
+        },
+    },
+];
+
+my $context = $raven->_construct_stacktrace_event($trace)->{'sentry.interfaces.Stacktrace'};
+
+is_deeply(
+    $context,
+    { frames => $frames },
+);
+
+done_testing;
+
+# line 127 "/bad/path/NoSuchFileEver.pm"
+sub a { $trace = Devel::StackTrace->new() }


### PR DESCRIPTION
Sometimes files mentioned in stack frames are not readable:

* the process called `chdir` after loading a module with a relative path
* the process changed its effective user id, and the file is no longer readable
* the process did `chroot` or changed its mount namespaces
* the file never existed, and a `# line` directive lied

In these cases, the `_get_lines_from_file` method would die, the exception would bubble up to `stacktrace_context`, and the context would end up containing a `Devel::StackTrace` object instead of plain data. And then JSON would die because it can't serialise the object.