### PR TITLE
Load *_proxy settings for LWP::UA

### DIFF
--- a/lib/Sentry/Raven.pm
+++ b/lib/Sentry/Raven.pm
@@ -673,9 +673,11 @@ sub _generate_auth_header {
 
 sub _build_json_obj { JSON::XS->new()->utf8(1)->pretty(1)->allow_nonref(1) }
 sub _build_ua_obj {
-    return LWP::UserAgent->new(
+    my $ua = LWP::UserAgent->new(
         keep_alive => 1,
     );
+    $ua->env_proxy;
+    return $ua;
 }
 
 =head1 EVENT CONTEXT


### PR DESCRIPTION
We have proxy to control external traffic. It is set with http_proxy and https_proxy env vars. Adding $ua->env_proxy would allow our app to reach sentry.io.